### PR TITLE
Add Role for pushing to ECR to Pipeline 

### DIFF
--- a/.github/workflows/eureka-ci.yml
+++ b/.github/workflows/eureka-ci.yml
@@ -46,7 +46,6 @@ jobs:
     env:
       AWS_REGION: eu-west-2
       ECR_REPO: eureka-server
-      ECR_URI: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
 
     steps:
       - name: Checkout code
@@ -64,8 +63,11 @@ jobs:
       - name: Build Docker image
         working-directory: ./eureka
         run: |
+          ECR_URI=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${AWS_REGION}.amazonaws.com
           docker build -t $ECR_REPO:latest .
           docker tag $ECR_REPO:latest $ECR_URI/$ECR_REPO:latest
 
       - name: Push Docker image to ECR
-        run: docker push $ECR_URI/$ECR_REPO:latest
+        run: |
+          ECR_URI=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${AWS_REGION}.amazonaws.com
+          docker push $ECR_URI/$ECR_REPO:latest

--- a/.github/workflows/eureka-ci.yml
+++ b/.github/workflows/eureka-ci.yml
@@ -9,18 +9,15 @@ on:
       - '.github/workflows/eureka-ci.yml'
 
 jobs:
-  build:
-    name: Build and Push Eureka
+  build-maven:
+    name: Build with Maven
     runs-on: ubuntu-latest
 
     permissions:
-      id-token: write       # Required for OIDC federation
-      contents: read        # Required for actions/checkout
+      contents: read
 
     env:
       AWS_REGION: eu-west-2
-      ECR_REPO: eureka-server
-      ECR_URI: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-west-2.amazonaws.com
 
     steps:
       - name: Checkout code
@@ -35,6 +32,25 @@ jobs:
       - name: Build with Maven
         working-directory: ./eureka
         run: mvn clean package
+
+  build-and-push-docker:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+
+    needs: build-maven
+
+    permissions:
+      id-token: write
+      contents: read
+
+    env:
+      AWS_REGION: eu-west-2
+      ECR_REPO: eureka-server
+      ECR_URI: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v3

--- a/.github/workflows/eureka-ci.yml
+++ b/.github/workflows/eureka-ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-maven:
-    name: Build with Maven
+    name: Verify Maven Build
     runs-on: ubuntu-latest
 
     permissions:
@@ -29,9 +29,9 @@ jobs:
           distribution: temurin
           java-version: '24'
 
-      - name: Build with Maven
+      - name: Verify Maven Build
         working-directory: ./eureka
-        run: mvn clean package
+        run: mvn verify
 
   build-and-push-docker:
     name: Build and Push Docker Image
@@ -60,7 +60,7 @@ jobs:
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Build Docker image
+      - name: Build Docker image (multi-stage)
         working-directory: ./eureka
         run: |
           ECR_URI=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${AWS_REGION}.amazonaws.com

--- a/.github/workflows/eureka-ci.yml
+++ b/.github/workflows/eureka-ci.yml
@@ -10,8 +10,17 @@ on:
 
 jobs:
   build:
-    name: Build Eureka
+    name: Build and Push Eureka
     runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write       # Required for OIDC federation
+      contents: read        # Required for actions/checkout
+
+    env:
+      AWS_REGION: eu-west-2
+      ECR_REPO: eureka-server
+      ECR_URI: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-west-2.amazonaws.com
 
     steps:
       - name: Checkout code
@@ -26,3 +35,21 @@ jobs:
       - name: Build with Maven
         working-directory: ./eureka
         run: mvn clean package
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-oidc-ecr-push
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build Docker image
+        working-directory: ./eureka
+        run: |
+          docker build -t $ECR_REPO:latest .
+          docker tag $ECR_REPO:latest $ECR_URI/$ECR_REPO:latest
+
+      - name: Push Docker image to ECR
+        run: docker push $ECR_URI/$ECR_REPO:latest

--- a/eureka/.dockerignore
+++ b/eureka/.dockerignore
@@ -1,0 +1,10 @@
+# Maven and IDE noise
+target/
+.git/
+.gitignore
+README.md
+*.iml
+.idea/
+
+# OS / editor files
+.DS_Store

--- a/eureka/Dockerfile
+++ b/eureka/Dockerfile
@@ -1,10 +1,10 @@
-# Stage 1: Build with Maven
-FROM maven:3.9.6-eclipse-temurin-24-alpine AS builder
+# Stage 1: Build with Maven + Java 21 (last supported official image)
+FROM maven:3.9.6-eclipse-temurin-21-alpine AS builder
 WORKDIR /app
 COPY . .
-RUN mvn clean package -DskipTests
+RUN mvn clean package
 
-# Stage 2: Build minimal runtime image
+# Stage 2: Run on Java 24 (your target)
 FROM eclipse-temurin:24-jdk-alpine
 VOLUME /tmp
 COPY --from=builder /app/target/*.jar app.jar

--- a/eureka/Dockerfile
+++ b/eureka/Dockerfile
@@ -1,5 +1,11 @@
-FROM eclipse-temurin:24-jdk
+# Stage 1: Build with Maven
+FROM maven:3.9.6-eclipse-temurin-24-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN mvn clean package -DskipTests
+
+# Stage 2: Build minimal runtime image
+FROM eclipse-temurin:24-jdk-alpine
 VOLUME /tmp
-ARG JAR_FILE=target/*.jar
-COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+COPY --from=builder /app/target/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/terraform/github-oicd.tf
+++ b/terraform/github-oicd.tf
@@ -1,3 +1,16 @@
+resource "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = [
+    "sts.amazonaws.com"
+  ]
+
+  thumbprint_list = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1" # This is GitHub's published thumbprint
+  ]
+}
+
+
 resource "aws_iam_role" "github_oidc_ecr_push" {
   name = "github-oidc-ecr-push"
 


### PR DESCRIPTION
### Summary
* Add the required steps to enable OIDC to push images to the ECR registry. 

This PR upgrades the Eureka server Dockerfile to a proper multi-stage build:

- 📦 **Maven build stage** now uses `maven:3.9.6-eclipse-temurin-21-alpine` as the last officially supported JDK image in Maven's Docker library.
- 🏃 **Runtime stage** uses `eclipse-temurin:24-jdk-alpine` to align with our target Java version for production.
- 🎯 Produces leaner, production-ready images containing only the built app, not Maven artifacts.
- 🚀 Removes the need for CI to manually copy JARs into the Docker context, simplifying CI workflows.

### Why Java 21 in build stage?

Docker Hub doesn't yet provide Maven images based on Java 24. Using Java 21 ensures a stable, official Maven image while running the final app with Java 24.

### Testing

✅ Built locally with:
```bash
docker build -t eureka-server:local ./eureka
docker run --rm -p 8761:8761 eureka-server:local
```

Closes #26 
