### PR TITLE
Add Battle Service CI and Docker Changes

### DIFF
--- a/.github/workflows/battle-service-ci.yml
+++ b/.github/workflows/battle-service-ci.yml
@@ -1,4 +1,4 @@
-name: battle-service CI
+name: Battle Service CI
 
 on:
   pull_request:
@@ -8,21 +8,15 @@ on:
       - 'battle-service/**'
       - '.github/workflows/battle-service-ci.yml'
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
-  build:
-    name: Build battle-service
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '24'
-
-      - name: Build with Maven
-        working-directory: ./battle-service
-        run: mvn clean package
+  build-and-push:
+    uses: ./.github/workflows/build-and-push.yml
+    with:
+      working-directory: ./battle-service
+      ecr-repo: battle-service
+    secrets:
+      aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}

--- a/battle-service/Dockerfile
+++ b/battle-service/Dockerfile
@@ -1,17 +1,12 @@
-# Use a recent Eclipse Temurin JDK image
-FROM eclipse-temurin:24-jdk
-
-# Create a working directory
+# Stage 1: Build with Maven + Java 21
+FROM maven:3.9.6-eclipse-temurin-21-alpine AS builder
 WORKDIR /app
+COPY . .
+RUN mvn clean package -DskipTests
 
-# Define the JAR file location (built externally)
-ARG JAR_FILE=target/*.jar
-
-# Copy the JAR file into the container
-COPY ${JAR_FILE} app.jar
-
-# Expose the application port
+# Stage 2: Run with Java 24
+FROM eclipse-temurin:24-jdk-alpine
+WORKDIR /app
+COPY --from=builder /app/target/*.jar app.jar
 EXPOSE 8080
-
-# Define the entry point
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]


### PR DESCRIPTION
### Summary

This PR updates the Battle Service with our standardized build process:

✅ Migrates CI to use our reusable `build-and-push.yml` workflow
✅ Adds a multi-stage Dockerfile:
  - Builds the app using Maven with Eclipse Temurin Java 21
  - Runs the app in a lightweight Eclipse Temurin Java 24 Alpine image
✅ Ensures consistency with Eureka and Config Server pipelines
✅ Produces optimized, secure, and production-ready Docker images

### Why

Standardizing all services ensures:
- Consistent build and deployment processes across the project
- Lean Docker images using multi-stage builds
- Easier maintenance and centralized CI improvements

### Testing

✅ Verified local build:
```bash
docker build -t battle-service:local ./battle-service
docker run --rm -p 8080:8080 battle-service:local
